### PR TITLE
Add http-schnorr-auth to repositories list

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,6 +8,7 @@ Below are some of the repositories in our organization:
 
 - [schema](https://github.com/nostrcg/schema) - Schema and context for the Nostr Linked Data Vocab
 - [did-nostr](https://github.com/nostrcg/did-nostr) - Nostr DID method Specification
+- [http-schnorr-auth](https://github.com/nostrcg/http-schnorr-auth) - HTTP Authentication Using Schnorr Signatures
 
 ## Work Items
 


### PR DESCRIPTION
## Summary
Add http-schnorr-auth to the organization README repositories list.

Following the work item proposal sent to public-nostr, http-schnorr-auth has reached v0.0.1 and should be listed alongside did-nostr and schema.

Fixes #3